### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,29 @@
+name: Build
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:plucky
+    steps:
+      - name: Install Node
+        run: |
+          apt-get update -y
+          apt-get install -y --no-install-recommends nodejs npm
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          apt-get install -y --no-install-recommends ninja-build meson g++-14 pkg-config libzstd-dev
+      - name: Build
+        run: |
+          CXX=g++-14 meson setup build -Ddefault_library=static -Dc_args=-static -Dc_link_args=-static
+          meson compile -C build
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dpatchz-${{ github.sha }}
+          path: build/dpatchz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+name: Release
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:plucky
+    steps:
+      - name: Install Node
+        run: |
+          apt-get update -y
+          apt-get install -y --no-install-recommends nodejs npm
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          apt-get install -y --no-install-recommends ninja-build meson g++-14 pkg-config libzstd-dev
+      - name: Build
+        run: |
+          CXX=g++-14 meson setup build -Ddefault_library=static -Dc_args=-static -Dc_link_args=-static
+          meson compile -C build
+      - name: Release
+        uses: ncipollo/release-action@v1
+        with:
+          name: dpatchz ${{ github.ref_name }}
+          artifacts: build/dpatchz


### PR DESCRIPTION
This PR adds a workflow that builds dpatchz as a static binary and then
- Uploads it as an artifact on every push
- Creates a new release with said binary whenever a new tag is pushed